### PR TITLE
Use optimized filepath.WalkDir function instead of filepath.Walk

### DIFF
--- a/finder.go
+++ b/finder.go
@@ -1,7 +1,7 @@
 package sysfont
 
 import (
-	"os"
+	"io/fs"
 	"path/filepath"
 	"strings"
 
@@ -32,11 +32,11 @@ func NewFinder(opts *FinderOpts) *Finder {
 	}
 
 	var fonts []*Font
-	walker := func(filename string, info os.FileInfo, err error) error {
+	walker := func(filename string, d fs.DirEntry, err error) error {
 		if err != nil {
 			return err
 		}
-		if info.IsDir() {
+		if d.IsDir() {
 			return nil
 		}
 
@@ -60,7 +60,7 @@ func NewFinder(opts *FinderOpts) *Finder {
 
 	// Traverse OS font directories.
 	for _, dir := range xdg.FontDirs {
-		if err := filepath.Walk(dir, walker); err != nil {
+		if err := filepath.WalkDir(dir, walker); err != nil {
 			continue
 		}
 	}


### PR DESCRIPTION
A simple test shows the performance difference

Test with filepath.Walk:
	goos: windows
	goarch: amd64
	pkg: github.com/adrg/sysfont
	cpu: Intel(R) Core(TM)2 Quad CPU    Q9400  @ 2.66GHz
	BenchmarkNewFinder-4           3         466802100 ns/op
	PASS
	ok      github.com/adrg/sysfont 2.978s	

Test with filepath.WalkDir:
	goos: windows
	goarch: amd64
	pkg: github.com/adrg/sysfont
	cpu: Intel(R) Core(TM)2 Quad CPU    Q9400  @ 2.66GHz
	BenchmarkNewFinder-4           3         427294700 ns/op
	PASS
	ok      github.com/adrg/sysfont 2.743s
