### PR TITLE
feat: add option for setting search paths

### DIFF
--- a/example_test.go
+++ b/example_test.go
@@ -15,6 +15,11 @@ func ExampleNewFinder() {
 		Extensions: []string{".ttf"},
 	})
 
+	// Create a new finder only searches the current directory for fonts.
+	finder = sysfont.NewFinder(&sysfont.FinderOpts{
+		SearchPaths: []string{"."},
+	})
+
 	// List detected fonts.
 	for _, font := range finder.List() {
 		fmt.Println(font.Family, font.Name, font.Filename)

--- a/example_test.go
+++ b/example_test.go
@@ -15,7 +15,7 @@ func ExampleNewFinder() {
 		Extensions: []string{".ttf"},
 	})
 
-	// Create a new finder only searches the current directory for fonts.
+	// Create a new finder that searches for fonts only in the current directory.
 	finder = sysfont.NewFinder(&sysfont.FinderOpts{
 		SearchPaths: []string{"."},
 	})

--- a/finder.go
+++ b/finder.go
@@ -19,6 +19,7 @@ type Finder struct {
 type FinderOpts struct {
 	// Extensions controls which types of font files the finder reports.
 	Extensions []string
+
 	// SearchPaths is a list of paths to search for fonts.
 	SearchPaths []string
 }
@@ -29,6 +30,9 @@ type FinderOpts struct {
 // Default options:
 //   Extensions: []string{".ttf", ".ttc", ".otf"}
 //   SearchPaths: xdg.FontDirs
+//
+// NOTE: See https://github.com/adrg/xdg#other-directories for more information
+// about the default search paths.
 func NewFinder(opts *FinderOpts) *Finder {
 	if opts == nil {
 		opts = &FinderOpts{Extensions: []string{".ttf", ".ttc", ".otf"}}

--- a/finder.go
+++ b/finder.go
@@ -19,6 +19,8 @@ type Finder struct {
 type FinderOpts struct {
 	// Extensions controls which types of font files the finder reports.
 	Extensions []string
+	// SearchPaths is a list of paths to search for fonts.
+	SearchPaths []string
 }
 
 // NewFinder returns a new font finder. If the opts parameter is nil, default
@@ -26,9 +28,14 @@ type FinderOpts struct {
 //
 // Default options:
 //   Extensions: []string{".ttf", ".ttc", ".otf"}
+//   SearchPaths: xdg.FontDirs
 func NewFinder(opts *FinderOpts) *Finder {
 	if opts == nil {
 		opts = &FinderOpts{Extensions: []string{".ttf", ".ttc", ".otf"}}
+	}
+
+	if len(opts.SearchPaths) == 0 {
+		opts.SearchPaths = xdg.FontDirs
 	}
 
 	var fonts []*Font
@@ -59,7 +66,7 @@ func NewFinder(opts *FinderOpts) *Finder {
 	}
 
 	// Traverse OS font directories.
-	for _, dir := range xdg.FontDirs {
+	for _, dir := range opts.SearchPaths {
 		if err := filepath.Walk(dir, walker); err != nil {
 			continue
 		}


### PR DESCRIPTION
Add a new SearchPaths option that allows you to set the search paths
for fonts without having to modify the package level xdg.FontDirs
slice.

The rationale for this is that you may want to limit searches to a particular directory or portable collection of fonts packaged with your app, or you may want to do both, but build two separate registries, one for system fonts and one for local fonts, and being able to explicitly set search paths enables that.